### PR TITLE
Adopt Keras 2.0 API for merge, Atrous, and fit_generator, etc

### DIFF
--- a/models.py
+++ b/models.py
@@ -125,7 +125,7 @@ def AtrousFCN_Vgg16_16s(input_shape=None, weight_decay=0., batch_momentum=0.9, b
     x = Conv2D(512, (3, 3), activation='relu', padding='same', name='block5_conv3', kernel_regularizer=l2(weight_decay))(x)
 
     # Convolutional layers transfered from fully-connected layers
-    x = AtrousConv2D(4096, (7, 7), activation='relu', padding='same', atrous_rate=(2, 2),
+    x = Conv2D(4096, (7, 7), activation='relu', padding='same', dilation_rate=(2, 2),
                       name='fc1', kernel_regularizer=l2(weight_decay))(x)
     x = Dropout(0.5)(x)
     x = Conv2D(4096, (1, 1), activation='relu', padding='same', name='fc2', kernel_regularizer=l2(weight_decay))(x)
@@ -222,7 +222,7 @@ def AtrousFCN_Resnet50_16s(input_shape = None, weight_decay=0., batch_momentum=0
     x = atrous_identity_block(3, [512, 512, 2048], stage=5, block='b', weight_decay=weight_decay, atrous_rate=(2, 2), batch_momentum=batch_momentum)(x)
     x = atrous_identity_block(3, [512, 512, 2048], stage=5, block='c', weight_decay=weight_decay, atrous_rate=(2, 2), batch_momentum=batch_momentum)(x)
     #classifying layer
-    #x = AtrousConv2D(classes, (3, 3), atrous_rate=(2, 2), kernel_initializer='normal', activation='linear', padding='same', strides=(1, 1), kernel_regularizer=l2(weight_decay))(x)
+    #x = Conv2D(classes, (3, 3), dilation_rate=(2, 2), kernel_initializer='normal', activation='linear', padding='same', strides=(1, 1), kernel_regularizer=l2(weight_decay))(x)
     x = Conv2D(classes, (1, 1), kernel_initializer='he_normal', activation='linear', padding='same', strides=(1, 1), kernel_regularizer=l2(weight_decay))(x)
     x = BilinearUpSampling2D(target_size=tuple(image_size))(x)
 

--- a/train.py
+++ b/train.py
@@ -132,6 +132,11 @@ def train(batch_size, epochs, lr_base, lr_power, weight_decay, classes,
         lines = fp.readlines()
         fp.close()
         return len(lines)
+
+    # from Keras documentation: Total number of steps (batches of samples) to yield from generator before declaring one epoch finished
+    # and starting the next epoch. It should typically be equal to the number of unique samples of your dataset divided by the batch size.
+    steps_per_epoch = int(np.ceil(get_file_len(train_file_path) / float(batch_size)))
+
     history = model.fit_generator(
         generator=train_datagen.flow_from_directory(
             file_path=train_file_path,
@@ -144,10 +149,10 @@ def train(batch_size, epochs, lr_base, lr_power, weight_decay, classes,
             ignore_label=ignore_label,
             # save_to_dir='Images/'
         ),
-        steps_per_epoch=get_file_len(train_file_path),
+        steps_per_epoch=steps_per_epoch,
         epochs=epochs,
         callbacks=callbacks,
-        nb_worker=4,
+        workers=4,
         # validation_data=val_datagen.flow_from_directory(
         #     file_path=val_file_path, data_dir=data_dir, data_suffix='.jpg',
         #     label_dir=label_dir, label_suffix='.png',classes=classes,

--- a/utils/BilinearUpSampling.py
+++ b/utils/BilinearUpSampling.py
@@ -56,7 +56,7 @@ class BilinearUpSampling2D(Layer):
         self.input_spec = [InputSpec(ndim=4)]
         super(BilinearUpSampling2D, self).__init__(**kwargs)
 
-    def get_output_shape_for(self, input_shape):
+    def compute_output_shape(self, input_shape):
         if self.data_format == 'channels_first':
             width = int(self.size[0] * input_shape[2] if input_shape[2] is not None else None)
             height = int(self.size[1] * input_shape[3] if input_shape[3] is not None else None)

--- a/utils/basics.py
+++ b/utils/basics.py
@@ -6,8 +6,8 @@ import tensorflow as tf
 def conv_relu(nb_filter, nb_row, nb_col, subsample=(1, 1), border_mode='same', bias = True, w_decay = 0.01):
     def f(x):
         with tf.name_scope('conv_relu'):
-            x = Convolution2D(nb_filter=nb_filter, nb_row=nb_row, nb_col=nb_col, subsample=subsample, bias=bias,
-                                 init="he_normal", W_regularizer=l2(w_decay), border_mode=border_mode)(x)
+            x = Conv2D(filters=nb_filter, kernel_size=(nb_row, nb_col), stride=subsample, use_bias=bias,
+                                 kernel_initializer="he_normal", W_regularizer=l2(w_decay), border_mode=border_mode)(x)
             x = Activation("relu")(x)
         return x
     return f
@@ -15,8 +15,8 @@ def conv_relu(nb_filter, nb_row, nb_col, subsample=(1, 1), border_mode='same', b
 def conv_bn(nb_filter, nb_row, nb_col, subsample=(1, 1), border_mode='same', bias = True, w_decay = 0.01):
     def f(x):
         with tf.name_scope('conv_bn'):
-            x = Convolution2D(nb_filter=nb_filter, nb_row=nb_row, nb_col=nb_col, subsample=subsample, bias=bias,
-                                 init="he_normal", W_regularizer=l2(w_decay), border_mode=border_mode)(x)
+            x = Conv2D(filters=nb_filter, kernel_size=(nb_row, nb_col), stride=subsample, use_bias=bias,
+                              kernel_initializer="he_normal", W_regularizer=l2(w_decay), border_mode=border_mode)(x)
             x = BatchNormalization(mode=0, axis=-1)(x)
         return x
     return f
@@ -24,8 +24,8 @@ def conv_bn(nb_filter, nb_row, nb_col, subsample=(1, 1), border_mode='same', bia
 def conv_bn_relu(nb_filter, nb_row, nb_col, subsample=(1, 1), border_mode='same', bias = True, w_decay = 0.01):
     def f(x):
         with tf.name_scope('conv_bn_relu'):
-            x = Convolution2D(nb_filter=nb_filter, nb_row=nb_row, nb_col=nb_col, subsample=subsample, bias=bias,
-                                 init="he_normal", W_regularizer=l2(w_decay), border_mode=border_mode)(x)
+            x = Conv2D(filters=nb_filter, kernel_size=(nb_row, nb_col), stride=subsample, use_bias=bias,
+                              kernel_initializer="he_normal", W_regularizer=l2(w_decay), border_mode=border_mode)(x)
             x = BatchNormalization(mode=0, axis=-1)(x)
             x = Activation("relu")(x)
         return x
@@ -36,16 +36,16 @@ def bn_relu_conv(nb_filter, nb_row, nb_col, subsample=(1, 1), border_mode='same'
         with tf.name_scope('bn_relu_conv'):
             x = BatchNormalization(mode=0, axis=-1)(x)
             x = Activation("relu")(x)
-            x = Convolution2D(nb_filter=nb_filter, nb_row=nb_row, nb_col=nb_col, subsample=subsample, bias=bias,
-                                 init="he_normal", W_regularizer=l2(w_decay), border_mode=border_mode)(x)
+            x = Conv2D(filters=nb_filter, kernel_size=(nb_row, nb_col), stride=subsample, use_bias=bias,
+                              kernel_initializer="he_normal", W_regularizer=l2(w_decay), border_mode=border_mode)(x)
         return x
     return f
 
 def atrous_conv_bn(nb_filter, nb_row, nb_col, atrous_rate=(2, 2), subsample=(1, 1), border_mode='same', bias = True, w_decay = 0.01):
     def f(x):
         with tf.name_scope('atrous_conv_bn'):
-            x = AtrousConvolution2D(nb_filter=nb_filter, nb_row=nb_row, nb_col=nb_col, atrous_rate=atrous_rate, subsample=subsample, bias=bias,
-                                 init="he_normal", W_regularizer=l2(w_decay), border_mode=border_mode)(x)
+            x = Conv2D(filters=nb_filter, kernel_size=(nb_row, nb_col), dilation_rate=atrous_rate, stride=subsample, use_bias=bias,
+                       kernel_initializer="he_normal", kernel_regularizer=l2(w_decay), padding=border_mode)(x)
             x = BatchNormalization(mode=0, axis=-1)(x)
         return x
     return f
@@ -53,8 +53,8 @@ def atrous_conv_bn(nb_filter, nb_row, nb_col, atrous_rate=(2, 2), subsample=(1, 
 def atrous_conv_bn_relu(nb_filter, nb_row, nb_col, atrous_rate=(2, 2), subsample=(1, 1), border_mode='same', bias = True, w_decay = 0.01):
     def f(x):
         with tf.name_scope('atrous_conv_bn_relu'):
-            x = AtrousConvolution2D(nb_filter=nb_filter, nb_row=nb_row, nb_col=nb_col, atrous_rate=atrous_rate, subsample=subsample, bias=bias,
-                                 init="he_normal", W_regularizer=l2(w_decay), border_mode=border_mode)(x)
+            x = Conv2D(filters=nb_filter, kernel_size=(nb_row, nb_col), dilation_rate=atrous_rate, stride=subsample, use_bias=bias,
+                       kernel_initializer="he_normal", kernel_regularizer=l2(w_decay), padding=border_mode)(x)
             x = BatchNormalization(mode=0, axis=-1)(x)
             x = Activation("relu")(x)
         return x

--- a/utils/resnet_helpers.py
+++ b/utils/resnet_helpers.py
@@ -1,4 +1,5 @@
 from keras.layers import *
+from keras.layers.merge import Add
 from keras.regularizers import l2
 
 # The original help functions from keras does not have weight regularizers, so I modified them.
@@ -32,7 +33,7 @@ def identity_block(kernel_size, filters, stage, block, weight_decay=0., batch_mo
         x = Conv2D(nb_filter3, (1, 1), name=conv_name_base + '2c', kernel_regularizer=l2(weight_decay))(x)
         x = BatchNormalization(axis=bn_axis, name=bn_name_base + '2c', momentum=batch_momentum)(x)
 
-        x = merge([x, input_tensor], mode='sum')
+        x = Add()([x, input_tensor])
         x = Activation('relu')(x)
         return x
     return f
@@ -73,7 +74,7 @@ def conv_block(kernel_size, filters, stage, block, weight_decay=0., strides=(2, 
                                  name=conv_name_base + '1', kernel_regularizer=l2(weight_decay))(input_tensor)
         shortcut = BatchNormalization(axis=bn_axis, name=bn_name_base + '1', momentum=batch_momentum)(shortcut)
 
-        x = merge([x, shortcut], mode='sum')
+        x = Add()([x, shortcut])
         x = Activation('relu')(x)
         return x
     return f
@@ -100,7 +101,7 @@ def atrous_identity_block(kernel_size, filters, stage, block, weight_decay=0., a
         x = BatchNormalization(axis=bn_axis, name=bn_name_base + '2a', momentum=batch_momentum)(x)
         x = Activation('relu')(x)
 
-        x = AtrousConv2D(nb_filter2, (kernel_size, kernel_size), atrous_rate=atrous_rate,
+        x = Conv2D(nb_filter2, (kernel_size, kernel_size), dilation_rate=atrous_rate,
                           padding='same', name=conv_name_base + '2b', kernel_regularizer=l2(weight_decay))(x)
         x = BatchNormalization(axis=bn_axis, name=bn_name_base + '2b', momentum=batch_momentum)(x)
         x = Activation('relu')(x)
@@ -108,7 +109,7 @@ def atrous_identity_block(kernel_size, filters, stage, block, weight_decay=0., a
         x = Conv2D(nb_filter3, (1, 1), name=conv_name_base + '2c', kernel_regularizer=l2(weight_decay))(x)
         x = BatchNormalization(axis=bn_axis, name=bn_name_base + '2c', momentum=batch_momentum)(x)
 
-        x = merge([x, input_tensor], mode='sum')
+        x = Add()([x, input_tensor])
         x = Activation('relu')(x)
         return x
     return f
@@ -135,7 +136,7 @@ def atrous_conv_block(kernel_size, filters, stage, block, weight_decay=0., strid
         x = BatchNormalization(axis=bn_axis, name=bn_name_base + '2a', momentum=batch_momentum)(x)
         x = Activation('relu')(x)
 
-        x = AtrousConv2D(nb_filter2, (kernel_size, kernel_size), padding='same', atrous_rate=atrous_rate,
+        x = Conv2D(nb_filter2, (kernel_size, kernel_size), padding='same', dilation_rate=atrous_rate,
                           name=conv_name_base + '2b', kernel_regularizer=l2(weight_decay))(x)
         x = BatchNormalization(axis=bn_axis, name=bn_name_base + '2b', momentum=batch_momentum)(x)
         x = Activation('relu')(x)
@@ -147,7 +148,7 @@ def atrous_conv_block(kernel_size, filters, stage, block, weight_decay=0., strid
                                  name=conv_name_base + '1', kernel_regularizer=l2(weight_decay))(input_tensor)
         shortcut = BatchNormalization(axis=bn_axis, name=bn_name_base + '1', momentum=batch_momentum)(shortcut)
 
-        x = merge([x, shortcut], mode='sum')
+        x = Add()([x, shortcut])
         x = Activation('relu')(x)
         return x
     return f


### PR DESCRIPTION
This commit will eliminate warnings from Keras complaining about deprecated APIs.

Specifically, it updates the following into Keras 2.0 API:
- AtrousConv2D
- fit_generator
- merge
- BilinearUpSampling2D